### PR TITLE
ci: add github action for building firmware

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,0 +1,23 @@
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Prepaire SPIFFS
+      working-directory: Firmware
+      shell: bash
+      run: |
+        sed -i -e 's/#spiffs_create_partition_image/spiffs_create_partition_image/' main/CMakeLists.txt
+
+    - name: esp-idf build
+      uses: espressif/esp-idf-ci-action@v1
+      with:
+        esp_idf_version: v5.0
+        target: esp32c3
+        path: 'Firmware'


### PR DESCRIPTION
Use the esp-idf action as it already contains the required tools.
