### PR TITLE
ci: build gateware / firmware on pull 

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build-gateware.yml
+++ b/.github/workflows/build-gateware.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This is important so that CI runs on pulls.